### PR TITLE
feat: add support for interpolating strings

### DIFF
--- a/sdk/composable-types.go
+++ b/sdk/composable-types.go
@@ -31,6 +31,11 @@ type ComposableGetValueFrom struct {
 	FormatTransformers []string `json:"format-transformers,omitempty"`
 }
 
+type ComposableInterpolateValuesFrom struct {
+	Format string                   `json:"format"`
+	Inputs []ComposableGetValueFrom `json:"inputs"`
+}
+
 // ObjectRef is the type that can be used for cross-resource references
 // +kubebuilder:object:generate=true
 type ObjectRef struct {


### PR DESCRIPTION
Supports the following syntax as described in #49

```yaml
interpolateValuesFrom:
  format: 'http://%s:%s'
  inputs:
    - kind: Service
      name: myservice
      path: '{.spec.clusterIP}'
    - kind: Service
      name: myservice
      path: '{.spec.ports[0].port}'
```