### PR TITLE
ISSUE-104 - Allow composable-manager to elevated permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -31,3 +31,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
Allow the `composable-manager-role` rights to manage cluster resources.

Resolves: https://github.com/composable-operator/composable/issues/104